### PR TITLE
[#9343][13.0][IMP] base_tier_validation - Notify reviewer by sequence…

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -55,7 +55,17 @@ class TierDefinition(models.Model):
     notify_on_create = fields.Boolean(
         string="Notify Reviewers on Creation",
         help="If set, all possible reviewers will be notified by email when "
-        "this definition is triggered.",
+             "this definition is triggered."
+    )
+    notify_by_sequence = fields.Boolean(
+        string="Notify Reviewers by Sequence",
+        help="If set, all possible reviewers will be notified by sequence when"
+             " this definition is triggered."
+    )
+    notify_creator_full_validated = fields.Boolean(
+        string="Notify Creator on Final Approbation Process",
+        help="If set, creator will be notified when"
+             " record is fully validated then this definition is triggered."
     )
     has_comment = fields.Boolean(string="Comment", default=False)
     approve_sequence = fields.Boolean(
@@ -68,3 +78,8 @@ class TierDefinition(models.Model):
     def onchange_review_type(self):
         self.reviewer_id = None
         self.reviewer_group_id = None
+
+    @api.onchange("approve_sequence")
+    def onchange_approve_sequence(self):
+        if not self.approve_sequence:
+            self.notify_by_sequence = False

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -222,6 +222,23 @@ class TierValidation(models.AbstractModel):
             and vals.get(self._state_field) in self._state_to
         )
 
+    def _notify_record_full_validated_body(self):
+        return _('All reviews were approved.')
+
+    def _notify_creator_record_full_validated(self, requested_by):
+        if hasattr(self, 'message_post') and \
+                hasattr(self, 'message_subscribe'):
+            for rec in self:
+                getattr(rec, 'message_subscribe')(
+                    partner_ids=requested_by.partner_id.ids)
+                # Notify about full validated record by sending email
+                # to creator
+                getattr(rec, 'message_post')(
+                    message_type='email',
+                    body=self._notify_record_full_validated_body(),
+                    partner_ids=requested_by.partner_id.ids
+                    )
+
     def _validate_tier(self, tiers=False):
         self.ensure_one()
         tier_reviews = tiers or self.review_ids
@@ -235,9 +252,30 @@ class TierValidation(models.AbstractModel):
                 "reviewed_date": fields.Datetime.now(),
             }
         )
-        for review in user_reviews:
-            rec = self.env[review.model].browse(review.res_id)
-            rec._notify_accepted_reviews()
+        user_pending_reviews = tier_reviews.\
+            filtered(lambda r: r.definition_id.notify_by_sequence
+                               and r.status == 'pending')
+        if user_pending_reviews:
+            sequence = user_pending_reviews.mapped('sequence')
+            sequence.sort()
+            my_sequence = sequence[0]
+            for review in user_pending_reviews:
+                if review.filtered(lambda r: r.sequence == my_sequence):
+                    rec = self.env[review.model].browse(review.res_id)
+                    rec._notify_review_accepted_requested_by_sequence(review)
+
+        else:
+            for review in user_reviews:
+                rec = self.env[review.model].browse(review.res_id)
+                rec._notify_accepted_reviews()
+
+        notify_creator = any(tier_reviews.
+                             filtered(lambda r: r.definition_id.
+                                      notify_creator_full_validated))
+
+        if self.validated and notify_creator and tier_reviews:
+            self._notify_creator_record_full_validated(tier_reviews[0].
+                                                       requested_by)
 
     def _get_requested_notification_subtype(self):
         return "base_tier_validation.mt_tier_validation_requested"
@@ -265,6 +303,10 @@ class TierValidation(models.AbstractModel):
             comment = has_comment.mapped("comment")[0]
             return _("A review was accepted. (%s)" % comment)
         return _("A review was accepted")
+
+    def _notify_accepted_reviews_by_sequence_body(self):
+        accepted_review = self._notify_accepted_reviews_body()
+        return accepted_review + _('. Ready for next review.')
 
     def _add_comment(self, validate_reject, reviews):
         wizard = self.env.ref("base_tier_validation.view_comment_wizard")
@@ -358,6 +400,34 @@ class TierValidation(models.AbstractModel):
                     subtype=self._get_requested_notification_subtype(),
                     body=rec._notify_requested_review_body(),
                 )
+    def _notify_review_requested_by_sequence(self, tier_review):
+        if hasattr(self, 'message_post') and \
+                hasattr(self, 'message_subscribe'):
+            for rec in self:
+                # Subscribe reviewers and notify
+                getattr(rec, 'message_subscribe')(
+                    partner_ids=tier_review.reviewer_ids.mapped(
+                        "partner_id").ids)
+                getattr(rec, 'message_post')(
+                    message_type='email',
+                    body=rec._notify_requested_review_body(),
+                    partner_ids=tier_review.reviewer_ids.mapped(
+                        "partner_id").ids)
+
+    def _notify_review_accepted_requested_by_sequence(self, tier_review):
+        if hasattr(self, 'message_post') and \
+                hasattr(self, 'message_subscribe'):
+            for rec in self:
+                getattr(rec, 'message_subscribe')(
+                    partner_ids=tier_review.reviewer_ids.mapped(
+                        "partner_id").ids)
+                # Notify state change by sending email to next reviewers
+                getattr(rec, 'message_post')(
+                    message_type='email',
+                    body=self._notify_accepted_reviews_by_sequence_body(),
+                    partner_ids=tier_review.reviewer_ids.mapped(
+                        "partner_id").ids
+                    )
 
     def request_validation(self):
         td_obj = self.env["tier.definition"]
@@ -382,7 +452,14 @@ class TierValidation(models.AbstractModel):
                                 }
                             )
                     self._update_counter()
-        self._notify_review_requested(created_trs)
+
+        if created_trs and \
+            not created_trs[0].definition_id.notify_on_create and \
+            created_trs[0].definition_id.notify_by_sequence:
+            self._notify_review_requested_by_sequence(created_trs[0])
+        else:
+            self._notify_review_requested(created_trs)
+
         return created_trs
 
     def restart_validation(self):

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -66,6 +66,8 @@
                             <field name="notify_on_create" />
                             <field name="has_comment" />
                             <field name="approve_sequence" />
+                            <field name="notify_by_sequence" attrs="{'invisible': [('approve_sequence', '=', False)]}"/>
+                            <field name="notify_creator_full_validated"/>
                         </group>
                     </group>
                     <group name="bottom">


### PR DESCRIPTION
… and notification to approbation process creator:

- Added onchange for approve_sequence;
- Added invisible attribute for notify_by_sequence;
- Added notify_creator_full_validated field in Tier Definition view;
- Sending an email to approbation process creator when record is full validated.